### PR TITLE
Fix bug with float pixel

### DIFF
--- a/CSS3Slider.Config.js
+++ b/CSS3Slider.Config.js
@@ -184,14 +184,16 @@ function CSS3Slider_Config (CSS3Slider, baseConfig) {
    */
   this._getSingleElementWidthInPx = function () {
     var baseObject = this.__CSS3Slider.getSlideTargetNode().children[0];
-    var width = parseInt(baseObject.offsetWidth);
+    var computedStyle = window.getComputedStyle(baseObject);
 
-    var marginLeft = parseInt(window.getComputedStyle(baseObject).getPropertyValue('margin-left')) || 0;
-    var marginRight = parseInt(window.getComputedStyle(baseObject).getPropertyValue('margin-right')) || 0;
+    var width = parseInt(computedStyle.getPropertyValue('width'));
+
+    var marginLeft = parseInt(computedStyle.getPropertyValue('margin-left')) || 0;
+    var marginRight = parseInt(computedStyle.getPropertyValue('margin-right')) || 0;
     var margin = marginLeft + marginRight;
 
-    var paddingLeft = parseInt(window.getComputedStyle(baseObject).getPropertyValue('padding-left')) || 0;
-    var paddingRight = parseInt(window.getComputedStyle(baseObject).getPropertyValue('padding-right')) || 0;
+    var paddingLeft = parseInt(computedStyle.getPropertyValue('padding-left')) || 0;
+    var paddingRight = parseInt(computedStyle.getPropertyValue('padding-right')) || 0;
     var padding = paddingLeft + paddingRight;
 
     var totalWidth = width + margin + padding;


### PR DESCRIPTION
e.g. screen width is 1903 and the elements have width 50%, therefore 951.5px. OffsetWidth is the uprounded value (952) and therefore the check for possible visible elements fails (comparison of 2 elements with 50% width and the screen width does not result that there is enough space for two elements)

Also prevents unnecessary reflows by putting the result of getComputedStyle in a variable