### PR TITLE
Fixed slideChildrenVisible

### DIFF
--- a/CSS3Slider.Config.js
+++ b/CSS3Slider.Config.js
@@ -183,6 +183,8 @@ function CSS3Slider_Config(CSS3Slider, baseConfig) {
       }
     }
 
+    if(slideChildrenVisible < 1) slideChildrenVisible = 1;
+
     return slideChildrenVisible;
   };
 


### PR DESCRIPTION
slideChildrenVisible can never be smaller than 1, and especially cannot be 0.

(See BCS #58516)